### PR TITLE
USWDS-Tutorial: Update banner markup 

### DIFF
--- a/_includes/sxs/part-five.html
+++ b/_includes/sxs/part-five.html
@@ -11,13 +11,13 @@ layout: default
 title: USWDS Tutorial
 ---
 </pre><pre class=add>
-&lt;section class="usa-banner" aria-label="Official government website"&gt;
+&lt;section class="usa-banner" aria-label="Official website of the United States government"&gt;
   &lt;div class="usa-accordion"&gt;
     &lt;header class="usa-banner__header"&gt;
 
     ...
 
-    &lt;/header"&gt;
+    &lt;/div&gt;
   &lt;/div&gt;
 &lt;/section&gt;</pre><pre class="blur">
 &lt;header class="opener"&gt;</pre>

--- a/_includes/uswds/banner.html
+++ b/_includes/uswds/banner.html
@@ -1,32 +1,38 @@
-<section class="usa-banner" aria-label="Official government website">
+<section
+  class="usa-banner"
+  aria-label="Official website of the United States government"
+>
   <div class="usa-accordion">
     <header class="usa-banner__header">
       <div class="usa-banner__inner">
         <div class="grid-col-auto">
           <img
+            aria-hidden="true"
             class="usa-banner__header-flag"
             src="{{ site.baseurl }}/assets/img/us_flag_small.png"
-            alt="U.S. flag"
+            alt=""
           />
         </div>
-        <div class="grid-col-fill tablet:grid-col-auto">
+        <div class="grid-col-fill tablet:grid-col-auto" aria-hidden="true">
           <p class="usa-banner__header-text">
             An official website of the United States government
           </p>
-          <p class="usa-banner__header-action" aria-hidden="true">
-            Here’s how you know
-          </p>
+          <p class="usa-banner__header-action">Here’s how you know</p>
         </div>
         <button
+          type="button"
           class="usa-accordion__button usa-banner__button"
           aria-expanded="false"
-          aria-controls="gov-banner-default"
+          aria-controls="gov-banner-default-default"
         >
           <span class="usa-banner__button-text">Here’s how you know</span>
         </button>
       </div>
     </header>
-    <div class="usa-banner__content usa-accordion__content" id="gov-banner-default">
+    <div
+      class="usa-banner__content usa-accordion__content"
+      id="gov-banner-default-default"
+    >
       <div class="grid-row grid-gap-lg">
         <div class="usa-banner__guidance tablet:grid-col-6">
           <img
@@ -38,9 +44,8 @@
           />
           <div class="usa-media-block__body">
             <p>
-              <strong> Official websites use .gov </strong>
-              <br />
-              A <strong>.gov</strong> website belongs to an official government
+              <strong>Official websites use .gov</strong><br />A
+              <strong>.gov</strong> website belongs to an official government
               organization in the United States.
             </p>
           </div>
@@ -55,9 +60,8 @@
           />
           <div class="usa-media-block__body">
             <p>
-              <strong> Secure .gov websites use HTTPS </strong>
-              <br />
-              A <strong>lock</strong> (
+              <strong>Secure .gov websites use HTTPS</strong><br />A
+              <strong>lock</strong> (
               <span class="icon-lock"
                 ><svg
                   xmlns="http://www.w3.org/2000/svg"
@@ -66,18 +70,18 @@
                   viewBox="0 0 52 64"
                   class="usa-banner__lock-image"
                   role="img"
-                  aria-labelledby="banner-lock-title-default banner-lock-description-default"
+                  aria-labelledby="banner-lock-description-default"
                   focusable="false"
                 >
                   <title id="banner-lock-title-default">Lock</title>
-                  <desc id="banner-lock-description-default">A locked padlock</desc>
+                  <desc id="banner-lock-description-default">Locked padlock icon</desc>
                   <path
                     fill="#000000"
                     fill-rule="evenodd"
                     d="M26 0c10.493 0 19 8.507 19 19v9h3a4 4 0 0 1 4 4v28a4 4 0 0 1-4 4H4a4 4 0 0 1-4-4V32a4 4 0 0 1 4-4h3v-9C7 8.507 15.507 0 26 0zm0 8c-5.979 0-10.843 4.77-10.996 10.712L15 19v9h22v-9c0-6.075-4.925-11-11-11z"
-                  /></svg
-              ></span>
-              ) or <strong>https://</strong> means you’ve safely connected to
+                  />
+                </svg> </span
+              >) or <strong>https://</strong> means you’ve safely connected to
               the .gov website. Share sensitive information only on official,
               secure websites.
             </p>


### PR DESCRIPTION
# Summary

Updated banner markup to reflect the latest changes as of `3.6.0`

## Related Issue

Closes #20 

## Problem statement

The include banner markup fell out of date with USWDS current banner markup. This is evident in some of the classes and component text.

## Solution

Replace markup with component example code from our site. I made sure to update file paths to reflect current templating specs.

I've also made a small change to the preview code example to match the closing tags of the banner. Hopefully, this will prevent any confusion.

## Testing & review

1. Confirm banner markup matches what's on [site](https://designsystem.digital.gov/components/banner/#component-code)
2. Confirm no build errors or visual regressions
3. Confirm closing tags in `Part Five` match actual banner closing tags