### PR TITLE
USWDS-Tutorial - Dependencies: Bump lodash

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -18,14 +18,15 @@
       "dev": true
     },
     "node_modules/@11ty/eleventy": {
-      "version": "2.0.0-canary.23",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-2.0.0-canary.23.tgz",
-      "integrity": "sha512-Vl8L/NjBvIgMusE3uBvWFCmUmiNw7OE6k1Dz9vRindqviJY9g77A8AFft7YEVPs7oVilzQFHVqtGeQigOrm6SA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-2.0.1.tgz",
+      "integrity": "sha512-t8XVUbCJByhVEa1RzO0zS2QzbL3wPY8ot1yUw9noqiSHxJWUwv6jiwm1/MZDPTYtkZH2ZHvdQIRQ5/SjG9XmLw==",
       "dev": true,
       "dependencies": {
         "@11ty/dependency-tree": "^2.0.1",
-        "@11ty/eleventy-dev-server": "^1.0.0-canary.14",
+        "@11ty/eleventy-dev-server": "^1.0.4",
         "@11ty/eleventy-utils": "^1.0.1",
+        "@11ty/lodash-custom": "^4.17.21",
         "@iarna/toml": "^2.2.5",
         "@sindresorhus/slugify": "^1.1.2",
         "bcp-47-normalize": "^1.1.1",
@@ -33,23 +34,20 @@
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.4",
         "dependency-graph": "^0.11.0",
-        "ejs": "^3.1.8",
+        "ejs": "^3.1.9",
         "fast-glob": "^3.2.12",
-        "graceful-fs": "^4.2.10",
+        "graceful-fs": "^4.2.11",
         "gray-matter": "^4.0.3",
         "hamljs": "^0.6.2",
         "handlebars": "^4.7.7",
         "is-glob": "^4.0.3",
         "iso-639-1": "^2.1.15",
         "kleur": "^4.1.5",
-        "liquidjs": "^10.3.3",
-        "lodash.chunk": "^4.2.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
-        "luxon": "^3.1.1",
+        "liquidjs": "^10.7.0",
+        "luxon": "^3.3.0",
         "markdown-it": "^13.0.1",
         "micromatch": "^4.0.5",
-        "minimist": "^1.2.7",
+        "minimist": "^1.2.8",
         "moo": "^0.5.2",
         "multimatch": "^5.0.0",
         "mustache": "^4.2.0",
@@ -62,7 +60,7 @@
         "pug": "^3.0.2",
         "recursive-copy": "^2.0.14",
         "semver": "^7.3.8",
-        "slugify": "^1.6.5"
+        "slugify": "^1.6.6"
       },
       "bin": {
         "eleventy": "cmd.js"
@@ -76,22 +74,22 @@
       }
     },
     "node_modules/@11ty/eleventy-dev-server": {
-      "version": "1.0.0-canary.14",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-dev-server/-/eleventy-dev-server-1.0.0-canary.14.tgz",
-      "integrity": "sha512-yIPRZCEieqe7943P8h+xG60db/82yp10iOgd8IRKiobLhWw43xDJtro8QnjTF4A9gRkx7UmulwTPkGbD1Lt8xQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-dev-server/-/eleventy-dev-server-1.0.4.tgz",
+      "integrity": "sha512-qVBmV2G1KF/0o5B/3fITlrrDHy4bONUI2YuN3/WJ3BNw4NU1d/we8XhKrlgq13nNvHoBx5czYp3LZt8qRG53Fg==",
       "dev": true,
       "dependencies": {
-        "@11ty/eleventy-utils": "^1.0.0",
+        "@11ty/eleventy-utils": "^1.0.1",
         "chokidar": "^3.5.3",
-        "debug": "^4.3.3",
+        "debug": "^4.3.4",
         "dev-ip": "^1.0.1",
-        "finalhandler": "^1.1.2",
+        "finalhandler": "^1.2.0",
         "mime": "^3.0.0",
-        "minimist": "^1.2.6",
-        "morphdom": "^2.6.1",
+        "minimist": "^1.2.8",
+        "morphdom": "^2.7.0",
         "please-upgrade-node": "^3.2.0",
         "ssri": "^8.0.1",
-        "ws": "^8.5.0"
+        "ws": "^8.13.0"
       },
       "bin": {
         "eleventy-dev-server": "cmd.js"
@@ -105,15 +103,28 @@
       }
     },
     "node_modules/@11ty/eleventy-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-1.0.1.tgz",
-      "integrity": "sha512-HPpCTz4PzudcQU+i+x6GSNHVqgnvRhnVYg5dLKaAoRWLN966odAGsBxKSyhF8i1MdlOPtsytYb2AGWP7jISC5w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-1.0.2.tgz",
+      "integrity": "sha512-Zy2leMK1DQR6Q6ZPSagv7QpJaAz9uVbb+RmVetYFp3foMeQtOSZx7w2u5daRFmP+PeNq9vO9H4xtBToYFWZwHA==",
       "dev": true,
       "dependencies": {
         "normalize-path": "^3.0.0"
       },
       "engines": {
         "node": ">=12"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/11ty"
+      }
+    },
+    "node_modules/@11ty/lodash-custom": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@11ty/lodash-custom/-/lodash-custom-4.17.21.tgz",
+      "integrity": "sha512-Mqt6im1xpb1Ykn3nbcCovWXK3ggywRJa+IXIdoz4wIIK+cvozADH63lexcuPpGS/gJ6/m2JxyyXDyupkMr5DHw==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
       },
       "funding": {
         "type": "opencollective",
@@ -362,9 +373,9 @@
       "dev": true
     },
     "node_modules/async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
       "dev": true
     },
     "node_modules/babel-walk": {
@@ -692,9 +703,9 @@
       "dev": true
     },
     "node_modules/ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
       "dev": true,
       "dependencies": {
         "jake": "^10.8.5"
@@ -826,9 +837,9 @@
       }
     },
     "node_modules/filelist/node_modules/minimatch": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-      "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+      "version": "5.1.6",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+      "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
       "dev": true,
       "dependencies": {
         "brace-expansion": "^2.0.1"
@@ -955,9 +966,9 @@
       }
     },
     "node_modules/graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "node_modules/gray-matter": {
@@ -1245,15 +1256,15 @@
       }
     },
     "node_modules/jake": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
-      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
       "dev": true,
       "dependencies": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
       },
       "bin": {
         "jake": "bin/cli.js"
@@ -1328,10 +1339,13 @@
       }
     },
     "node_modules/liquidjs": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.3.3.tgz",
-      "integrity": "sha512-o6s4rOn81x0FlF9SJEQEx3f/j3iL0Iq3zqOsbFEcsoi7Ivn6jEXBEi2Xl5k0oYc7KqYS54uGOa9XC4Ahk7zdFA==",
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.10.0.tgz",
+      "integrity": "sha512-f4gPvCq4uV4Fm5YezVUQoAMPmBMEuIE2LvgCnzyWoPRx+ZefH6b8DU2eb7znltRqATHF8zYvOsd5FD2z1spJgg==",
       "dev": true,
+      "dependencies": {
+        "commander": "^10.0.0"
+      },
       "bin": {
         "liquid": "bin/liquid.js",
         "liquidjs": "bin/liquid.js"
@@ -1344,34 +1358,25 @@
         "url": "https://opencollective.com/liquidjs"
       }
     },
+    "node_modules/liquidjs/node_modules/commander": {
+      "version": "10.0.1",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+      "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+      "dev": true,
+      "engines": {
+        "node": ">=14"
+      }
+    },
     "node_modules/list-to-array": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/list-to-array/-/list-to-array-1.1.0.tgz",
       "integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g==",
       "dev": true
     },
-    "node_modules/lodash.chunk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
-      "dev": true
-    },
     "node_modules/lodash.deburr": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
       "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
-      "dev": true
-    },
-    "node_modules/lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
-    },
-    "node_modules/lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
       "dev": true
     },
     "node_modules/lru-cache": {
@@ -1515,9 +1520,9 @@
       }
     },
     "node_modules/minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -1554,9 +1559,9 @@
       "dev": true
     },
     "node_modules/morphdom": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.6.1.tgz",
-      "integrity": "sha512-Y8YRbAEP3eKykroIBWrjcfMw7mmwJfjhqdpSvoqinu8Y702nAwikpXcNFDiIkyvfCLxLM9Wu95RZqo4a9jFBaA==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.2.tgz",
+      "integrity": "sha512-Dqb/lHFyTi7SZpY0a5R4I/0Edo+iPMbaUexsHHsLAByyixCDiLHPHyVoKVmrpL0THcT7V9Cgev9y21TQYq6wQg==",
       "dev": true
     },
     "node_modules/ms": {
@@ -2114,9 +2119,9 @@
       }
     },
     "node_modules/slugify": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
-      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
       "dev": true,
       "engines": {
         "node": ">=8.0.0"
@@ -2310,16 +2315,16 @@
       "dev": true
     },
     "node_modules/ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "engines": {
         "node": ">=10.0.0"
       },
       "peerDependencies": {
         "bufferutil": "^4.0.1",
-        "utf-8-validate": "^5.0.2"
+        "utf-8-validate": ">=5.0.2"
       },
       "peerDependenciesMeta": {
         "bufferutil": {
@@ -2345,14 +2350,15 @@
       "dev": true
     },
     "@11ty/eleventy": {
-      "version": "2.0.0-canary.23",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-2.0.0-canary.23.tgz",
-      "integrity": "sha512-Vl8L/NjBvIgMusE3uBvWFCmUmiNw7OE6k1Dz9vRindqviJY9g77A8AFft7YEVPs7oVilzQFHVqtGeQigOrm6SA==",
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy/-/eleventy-2.0.1.tgz",
+      "integrity": "sha512-t8XVUbCJByhVEa1RzO0zS2QzbL3wPY8ot1yUw9noqiSHxJWUwv6jiwm1/MZDPTYtkZH2ZHvdQIRQ5/SjG9XmLw==",
       "dev": true,
       "requires": {
         "@11ty/dependency-tree": "^2.0.1",
-        "@11ty/eleventy-dev-server": "^1.0.0-canary.14",
+        "@11ty/eleventy-dev-server": "^1.0.4",
         "@11ty/eleventy-utils": "^1.0.1",
+        "@11ty/lodash-custom": "^4.17.21",
         "@iarna/toml": "^2.2.5",
         "@sindresorhus/slugify": "^1.1.2",
         "bcp-47-normalize": "^1.1.1",
@@ -2360,23 +2366,20 @@
         "cross-spawn": "^7.0.3",
         "debug": "^4.3.4",
         "dependency-graph": "^0.11.0",
-        "ejs": "^3.1.8",
+        "ejs": "^3.1.9",
         "fast-glob": "^3.2.12",
-        "graceful-fs": "^4.2.10",
+        "graceful-fs": "^4.2.11",
         "gray-matter": "^4.0.3",
         "hamljs": "^0.6.2",
         "handlebars": "^4.7.7",
         "is-glob": "^4.0.3",
         "iso-639-1": "^2.1.15",
         "kleur": "^4.1.5",
-        "liquidjs": "^10.3.3",
-        "lodash.chunk": "^4.2.0",
-        "lodash.get": "^4.4.2",
-        "lodash.set": "^4.3.2",
-        "luxon": "^3.1.1",
+        "liquidjs": "^10.7.0",
+        "luxon": "^3.3.0",
         "markdown-it": "^13.0.1",
         "micromatch": "^4.0.5",
-        "minimist": "^1.2.7",
+        "minimist": "^1.2.8",
         "moo": "^0.5.2",
         "multimatch": "^5.0.0",
         "mustache": "^4.2.0",
@@ -2389,36 +2392,42 @@
         "pug": "^3.0.2",
         "recursive-copy": "^2.0.14",
         "semver": "^7.3.8",
-        "slugify": "^1.6.5"
+        "slugify": "^1.6.6"
       }
     },
     "@11ty/eleventy-dev-server": {
-      "version": "1.0.0-canary.14",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-dev-server/-/eleventy-dev-server-1.0.0-canary.14.tgz",
-      "integrity": "sha512-yIPRZCEieqe7943P8h+xG60db/82yp10iOgd8IRKiobLhWw43xDJtro8QnjTF4A9gRkx7UmulwTPkGbD1Lt8xQ==",
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-dev-server/-/eleventy-dev-server-1.0.4.tgz",
+      "integrity": "sha512-qVBmV2G1KF/0o5B/3fITlrrDHy4bONUI2YuN3/WJ3BNw4NU1d/we8XhKrlgq13nNvHoBx5czYp3LZt8qRG53Fg==",
       "dev": true,
       "requires": {
-        "@11ty/eleventy-utils": "^1.0.0",
+        "@11ty/eleventy-utils": "^1.0.1",
         "chokidar": "^3.5.3",
-        "debug": "^4.3.3",
+        "debug": "^4.3.4",
         "dev-ip": "^1.0.1",
-        "finalhandler": "^1.1.2",
+        "finalhandler": "^1.2.0",
         "mime": "^3.0.0",
-        "minimist": "^1.2.6",
-        "morphdom": "^2.6.1",
+        "minimist": "^1.2.8",
+        "morphdom": "^2.7.0",
         "please-upgrade-node": "^3.2.0",
         "ssri": "^8.0.1",
-        "ws": "^8.5.0"
+        "ws": "^8.13.0"
       }
     },
     "@11ty/eleventy-utils": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-1.0.1.tgz",
-      "integrity": "sha512-HPpCTz4PzudcQU+i+x6GSNHVqgnvRhnVYg5dLKaAoRWLN966odAGsBxKSyhF8i1MdlOPtsytYb2AGWP7jISC5w==",
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@11ty/eleventy-utils/-/eleventy-utils-1.0.2.tgz",
+      "integrity": "sha512-Zy2leMK1DQR6Q6ZPSagv7QpJaAz9uVbb+RmVetYFp3foMeQtOSZx7w2u5daRFmP+PeNq9vO9H4xtBToYFWZwHA==",
       "dev": true,
       "requires": {
         "normalize-path": "^3.0.0"
       }
+    },
+    "@11ty/lodash-custom": {
+      "version": "4.17.21",
+      "resolved": "https://registry.npmjs.org/@11ty/lodash-custom/-/lodash-custom-4.17.21.tgz",
+      "integrity": "sha512-Mqt6im1xpb1Ykn3nbcCovWXK3ggywRJa+IXIdoz4wIIK+cvozADH63lexcuPpGS/gJ6/m2JxyyXDyupkMr5DHw==",
+      "dev": true
     },
     "@babel/helper-string-parser": {
       "version": "7.19.4",
@@ -2598,9 +2607,9 @@
       "dev": true
     },
     "async": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/async/-/async-3.2.4.tgz",
-      "integrity": "sha512-iAB+JbDEGXhyIUavoDl9WP/Jj106Kz9DEn1DPgYw5ruDn0e3Wgi3sKFm55sASdGBNOQB8F59d9qQ7deqrHA8wQ==",
+      "version": "3.2.5",
+      "resolved": "https://registry.npmjs.org/async/-/async-3.2.5.tgz",
+      "integrity": "sha512-baNZyqaaLhyLVKm/DlvdW051MSgO6b8eVfIezl9E5PqWxFgzLm/wQntEW4zOytVburDEr0JlALEpdOFwvErLsg==",
       "dev": true
     },
     "babel-walk": {
@@ -2842,9 +2851,9 @@
       "dev": true
     },
     "ejs": {
-      "version": "3.1.8",
-      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-      "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+      "version": "3.1.9",
+      "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+      "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
       "dev": true,
       "requires": {
         "jake": "^10.8.5"
@@ -2939,9 +2948,9 @@
           }
         },
         "minimatch": {
-          "version": "5.1.1",
-          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-          "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+          "version": "5.1.6",
+          "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+          "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
           "dev": true,
           "requires": {
             "brace-expansion": "^2.0.1"
@@ -3044,9 +3053,9 @@
       }
     },
     "graceful-fs": {
-      "version": "4.2.10",
-      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
-      "integrity": "sha512-9ByhssR2fPVsNZj478qUUbKfmL0+t5BDVyjShtyZZLiK7ZDAArFFfopyOTj0M05wE2tJPisA4iTnnXl2YoPvOA==",
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
       "dev": true
     },
     "gray-matter": {
@@ -3256,15 +3265,15 @@
       "dev": true
     },
     "jake": {
-      "version": "10.8.5",
-      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.5.tgz",
-      "integrity": "sha512-sVpxYeuAhWt0OTWITwT98oyV0GsXyMlXCF+3L1SuafBVUIr/uILGRB+NqwkzhgXKvoJpDIpQvqkUALgdmQsQxw==",
+      "version": "10.8.7",
+      "resolved": "https://registry.npmjs.org/jake/-/jake-10.8.7.tgz",
+      "integrity": "sha512-ZDi3aP+fG/LchyBzUM804VjddnwfSfsdeYkwt8NcbKRvo4rFkjhs456iLFn3k2ZUWvNe4i48WACDbza8fhq2+w==",
       "dev": true,
       "requires": {
         "async": "^3.2.3",
         "chalk": "^4.0.2",
-        "filelist": "^1.0.1",
-        "minimatch": "^3.0.4"
+        "filelist": "^1.0.4",
+        "minimatch": "^3.1.2"
       }
     },
     "js-stringify": {
@@ -3321,10 +3330,21 @@
       }
     },
     "liquidjs": {
-      "version": "10.3.3",
-      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.3.3.tgz",
-      "integrity": "sha512-o6s4rOn81x0FlF9SJEQEx3f/j3iL0Iq3zqOsbFEcsoi7Ivn6jEXBEi2Xl5k0oYc7KqYS54uGOa9XC4Ahk7zdFA==",
-      "dev": true
+      "version": "10.10.0",
+      "resolved": "https://registry.npmjs.org/liquidjs/-/liquidjs-10.10.0.tgz",
+      "integrity": "sha512-f4gPvCq4uV4Fm5YezVUQoAMPmBMEuIE2LvgCnzyWoPRx+ZefH6b8DU2eb7znltRqATHF8zYvOsd5FD2z1spJgg==",
+      "dev": true,
+      "requires": {
+        "commander": "^10.0.0"
+      },
+      "dependencies": {
+        "commander": {
+          "version": "10.0.1",
+          "resolved": "https://registry.npmjs.org/commander/-/commander-10.0.1.tgz",
+          "integrity": "sha512-y4Mg2tXshplEbSGzx7amzPwKKOCGuoSRP/CjEdwwk0FOGlUbq6lKuoyDZTNZkmxHdJtp54hdfY/JUrdL7Xfdug==",
+          "dev": true
+        }
+      }
     },
     "list-to-array": {
       "version": "1.1.0",
@@ -3332,28 +3352,10 @@
       "integrity": "sha512-+dAZZ2mM+/m+vY9ezfoueVvrgnHIGi5FvgSymbIgJOFwiznWyA59mav95L+Mc6xPtL3s9gm5eNTlNtxJLbNM1g==",
       "dev": true
     },
-    "lodash.chunk": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/lodash.chunk/-/lodash.chunk-4.2.0.tgz",
-      "integrity": "sha512-ZzydJKfUHJwHa+hF5X66zLFCBrWn5GeF28OHEr4WVWtNDXlQ/IjWKPBiikqKo2ne0+v6JgCgJ0GzJp8k8bHC7w==",
-      "dev": true
-    },
     "lodash.deburr": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/lodash.deburr/-/lodash.deburr-4.1.0.tgz",
       "integrity": "sha512-m/M1U1f3ddMCs6Hq2tAsYThTBDaAKFDX3dwDo97GEYzamXi9SqUpjWi/Rrj/gf3X2n8ktwgZrlP1z6E3v/IExQ==",
-      "dev": true
-    },
-    "lodash.get": {
-      "version": "4.4.2",
-      "resolved": "https://registry.npmjs.org/lodash.get/-/lodash.get-4.4.2.tgz",
-      "integrity": "sha512-z+Uw/vLuy6gQe8cfaFWD7p0wVv8fJl3mbzXh33RS+0oW2wvUqiRXiQ69gLWSLpgB5/6sU+r6BlQR0MBILadqTQ==",
-      "dev": true
-    },
-    "lodash.set": {
-      "version": "4.3.2",
-      "resolved": "https://registry.npmjs.org/lodash.set/-/lodash.set-4.3.2.tgz",
-      "integrity": "sha512-4hNPN5jlm/N/HLMCO43v8BXKq9Z7QdAGc/VGrRD61w8gN9g/6jF9A4L1pbUgBLCffi0w9VsXfTOij5x8iTyFvg==",
       "dev": true
     },
     "lru-cache": {
@@ -3465,9 +3467,9 @@
       }
     },
     "minimist": {
-      "version": "1.2.7",
-      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.7.tgz",
-      "integrity": "sha512-bzfL1YUZsP41gmu/qjrEk0Q6i2ix/cVeAhbCbqH9u3zYutS1cLg00qhrD0M2MVdCcx4Sc0UpP2eBWo9rotpq6g==",
+      "version": "1.2.8",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
+      "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "dev": true
     },
     "minipass": {
@@ -3495,9 +3497,9 @@
       "dev": true
     },
     "morphdom": {
-      "version": "2.6.1",
-      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.6.1.tgz",
-      "integrity": "sha512-Y8YRbAEP3eKykroIBWrjcfMw7mmwJfjhqdpSvoqinu8Y702nAwikpXcNFDiIkyvfCLxLM9Wu95RZqo4a9jFBaA==",
+      "version": "2.7.2",
+      "resolved": "https://registry.npmjs.org/morphdom/-/morphdom-2.7.2.tgz",
+      "integrity": "sha512-Dqb/lHFyTi7SZpY0a5R4I/0Edo+iPMbaUexsHHsLAByyixCDiLHPHyVoKVmrpL0THcT7V9Cgev9y21TQYq6wQg==",
       "dev": true
     },
     "ms": {
@@ -3931,9 +3933,9 @@
       "dev": true
     },
     "slugify": {
-      "version": "1.6.5",
-      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.5.tgz",
-      "integrity": "sha512-8mo9bslnBO3tr5PEVFzMPIWwWnipGS0xVbYf65zxDqfNwmzYn1LpiKNrR6DlClusuvo+hDHd1zKpmfAe83NQSQ==",
+      "version": "1.6.6",
+      "resolved": "https://registry.npmjs.org/slugify/-/slugify-1.6.6.tgz",
+      "integrity": "sha512-h+z7HKHYXj6wJU+AnS/+IH8Uh9fdcX1Lrhg1/VMdf9PwoBQXFcXiAdsy2tSK0P6gKwJLXp02r90ahUCqHk9rrw==",
       "dev": true
     },
     "snyk": {
@@ -4070,9 +4072,9 @@
       "dev": true
     },
     "ws": {
-      "version": "8.11.0",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-8.11.0.tgz",
-      "integrity": "sha512-HPG3wQd9sNQoT9xHyNCXoDUa+Xw/VevmY9FoHyQ+g+rrMn4j6FB4np7Z0OhdTgjx6MgQLK7jwSy1YecU1+4Asg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.16.0.tgz",
+      "integrity": "sha512-HS0c//TP7Ina87TfiPUz1rQzMhHrl/SG2guqRcTOIUYD2q8uhUdNHZYJUaQ8aTGPzCh+c6oawMKW35nFl1dxyQ==",
       "dev": true,
       "requires": {}
     },


### PR DESCRIPTION
# Summary

`npm audit fix` to fix `2 high` vulnerability. This repo has `0 vulnerabilities` after this fix.

## Related issue

Resolves https://github.com/uswds/uswds-tutorial/security/dependabot/15

## Testing

- [ ] `npm install` without errors
- [ ] 0 vulnerabilities
- [ ] `npm run start` without errors