### PR TITLE
March MC - Exercise 3: Standalone testimonial`

### DIFF
--- a/_includes/sxs/02-extending/testimonial.html
+++ b/_includes/sxs/02-extending/testimonial.html
@@ -1,19 +1,17 @@
-<div class="usa-card ut-testimonial">
-  <div class="usa-card__container">
-    <svg class="usa-icon ut-testimonial__icon" aria-hidden="true" focusable="false" role="img" height="50px" width="50px">
-      <use xlink:href="/assets/uswds/img/sprite.svg#format_quote"></use>
-    </svg>
-    <div class="usa-card__body ut-testimonial__quote">
-      <p>
-        "Wow, this component sure is great"
-      </p>
-    </div>
-    <div class="usa-card__footer ut-testimonial__footer">
-      <img src="https://doodleipsum.com/100x100/avatar-5?bg=a5a8eb&shape=circle&n=1" alt="Profile pic">
-      <div class="ut-testimonial__profile">
-        <p class="ut-testimonial__profile-name">Person McGuy</p>
-        <p class="ut-testimonial__profile-title">USWDS User</p>
-      </div>
+<div class="ut-testimonial">
+  <svg class="usa-icon ut-testimonial__icon" aria-hidden="true" focusable="false" role="img" height="50px" width="50px">
+    <use xlink:href="/assets/uswds/img/sprite.svg#format_quote"></use>
+  </svg>
+  <div class="ut-testimonial__quote">
+    <p>
+      "Wow, this component sure is great"
+    </p>
+  </div>
+  <div class="ut-testimonial__footer">
+    <img src="https://doodleipsum.com/100x100/avatar-5?bg=a5a8eb&shape=circle&n=1" alt="Profile pic">
+    <div class="ut-testimonial__profile">
+      <p class="ut-testimonial__profile-name">Person McGuy</p>
+      <p class="ut-testimonial__profile-title">USWDS User</p>
     </div>
   </div>
 </div>

--- a/assets/css/components/ut-testimonial.scss
+++ b/assets/css/components/ut-testimonial.scss
@@ -2,8 +2,12 @@
 
 $ut-testimonial-icon-color: color("indigo-30");
 
-.ut-testimonial .usa-card__container {
-  @include set-text-and-bg("indigo-70v", "indigo-20");
+.ut-testimonial {
+  @include u-bg("indigo-10");
+  @include u-padding(3);
+  @include u-margin-x(1);
+  @include u-border($theme-card-border-width);
+  @include u-radius($theme-card-border-radius);
 }
 
 .ut-testimonial__icon {
@@ -20,6 +24,7 @@ $ut-testimonial-icon-color: color("indigo-30");
 .ut-testimonial__footer {
   @include u-display("flex");
   @include u-flex("row");
+  @include u-margin-top(3);
 }
 
 .ut-testimonial img {
@@ -31,7 +36,7 @@ $ut-testimonial-icon-color: color("indigo-30");
 }
 
 .ut-testimonial__profile-name {
-  @include u-text("indigo-10v");
+  @include u-text("indigo-70v");
 }
 
 .ut-testimonial__profile-title {


### PR DESCRIPTION
# Summary

This is an alternative approach to building off of `usa-card` to build the custom `ut-testimonial` component. This approach instead removes all references and styles inherited from `usa-card` and builds it all custom.

The one exception is using `$theme-card-border-radius` and `$theme-card-border-width` to show how users can add USWDS theme settings for uniformity across their projects.