### PR TITLE
USWDS-Tutorial - POAM: December '24

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^2.0.1",
-        "snyk": "^1.1293.0"
+        "snyk": "^1.1294.0"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -2460,9 +2460,9 @@
       }
     },
     "node_modules/snyk": {
-      "version": "1.1293.0",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1293.0.tgz",
-      "integrity": "sha512-kAMTPHXlOJhcogYk1P2GMmnIIao7ZiQDCznSIdUbQGW68hoaWKghVUlLz4ny+LjjqemE1KII/amVwoFTRoNIlA==",
+      "version": "1.1294.0",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1294.0.tgz",
+      "integrity": "sha512-4RBj3Lfccz5+6L2Kw9bt7icF+ex3antwt9PkSl2oEulI7mgqvc8VUFLnezg8c6PY60IPM9DrSSmNjXBac10I3Q==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^3.0.0",
-        "snyk": "^1.1294.0"
+        "snyk": "^1.1294.3"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -2483,9 +2483,9 @@
       }
     },
     "node_modules/snyk": {
-      "version": "1.1294.2",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1294.2.tgz",
-      "integrity": "sha512-m6F+go3Fj///rfL+qfGZAslYBFxVtCgZ5PkKcoRjewmbgfisfTFPP6/SyWV6fH54hb7k00t2EEHYO02vRD4g+g==",
+      "version": "1.1294.3",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1294.3.tgz",
+      "integrity": "sha512-ZF+F2bv293HmpFxZCV0x8hT3rQGOl6rPDoJq/TqBT1i5/nZypfn8v4A1Q4m6zUSUs1g6WJsS8QR5wTlR/eSvMQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -666,10 +666,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1985,10 +1986,11 @@
       "dev": true
     },
     "node_modules/path-to-regexp": {
-      "version": "6.2.2",
-      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.2.2.tgz",
-      "integrity": "sha512-GQX3SSMokngb36+whdpRXE+3f9V8UzyAorlYvOGx87ufGHehNTn5lCxrKtLyZ4Yl/wEKnNnr98ZzOwwDZV5ogw==",
-      "dev": true
+      "version": "6.3.0",
+      "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-6.3.0.tgz",
+      "integrity": "sha512-Yhpw4T9C6hPpgPeA28us07OJeqZ5EzQTkbfwuhsUg0c237RomFoETJgmp2sa3F/41gfLE6G5cqcYwznmeEeOlQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -759,10 +759,11 @@
       "license": "MIT"
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.3.tgz",
-      "integrity": "sha512-iRDPJKUPVEND7dHPO8rkbOnPpyDygcDFtWjpeWNCgy8WP2rXcxXL8TskReQl6OrB2G7+UJrags1q15Fudc7G6w==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^2.0.1",
-    "snyk": "^1.1293.0"
+    "snyk": "^1.1294.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",
-    "snyk": "^1.1294.0"
+    "snyk": "^1.1294.3"
   }
 }


### PR DESCRIPTION
# Summary

POAM updates for November + December 2024

## Related issue

[USWDS-Team - POAM: December 2024](https://github.com/uswds/uswds-team/issues/413)

## Vulnerabilities

**Before**

```jsx
1 high severity vulnerabilities
```

**After**

```jsx
found 0 vulnerabilities
```

## Dependency updates

| Dependency Name | Old Version | New Version |
| --- | --- | --- |
| snyk | ^1.1293.0 | ^^1.1294.3 |

## Testing and review

1. Pull down branch and install
2. Confirm no installation errors
3. Run `npm run start`
4. Confirm no build errors
5. Confirm there are no regressions on local build
6. Run `npm run test` and confirm snyk test runs without error