### PR TITLE
USWDS-Tutorial - POAM: February '25

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,7 @@
       "license": "CC0-1.0",
       "devDependencies": {
         "@11ty/eleventy": "^3.0.0",
-        "snyk": "^1.1294.3"
+        "snyk": "^1.1295.3"
       }
     },
     "node_modules/@11ty/dependency-tree": {
@@ -2483,9 +2483,9 @@
       }
     },
     "node_modules/snyk": {
-      "version": "1.1294.3",
-      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1294.3.tgz",
-      "integrity": "sha512-ZF+F2bv293HmpFxZCV0x8hT3rQGOl6rPDoJq/TqBT1i5/nZypfn8v4A1Q4m6zUSUs1g6WJsS8QR5wTlR/eSvMQ==",
+      "version": "1.1295.3",
+      "resolved": "https://registry.npmjs.org/snyk/-/snyk-1.1295.3.tgz",
+      "integrity": "sha512-PFPetFXVMx5kt49WraLbr1Lw36jikktxQeOjaK3y/0Bjgm1e1rRjTsKYI83lINhkxUuSRBf9MCm8QUcOEYZiaw==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",

--- a/package.json
+++ b/package.json
@@ -10,6 +10,6 @@
   },
   "devDependencies": {
     "@11ty/eleventy": "^3.0.0",
-    "snyk": "^1.1294.3"
+    "snyk": "^1.1295.3"
   }
 }


### PR DESCRIPTION
# Summary

POAM updates for February 2025

## Related issue

[USWDS-Team - POAM: February 2025](https://github.com/uswds/uswds-team/issues/477)

## Vulnerabilities

```jsx
found 0 vulnerabilities
```

## Dependency updates

| Dependency Name | Old Version | New Version |
| --- | --- | --- |
| snyk | ^1.1294.3 | ^1.1295.3 |

## Testing and review

1. Pull down branch and install
2. Confirm no installation errors
3. Run `npm run start`
4. Confirm no build errors
5. Confirm there are no regressions on local build
6. Run `npm run test` and confirm snyk test runs without error